### PR TITLE
1338-yc-matlab-version2020b

### DIFF
--- a/braph2genesis/src/ds/Element.m
+++ b/braph2genesis/src/ds/Element.m
@@ -1601,6 +1601,9 @@ classdef Element < Category & Format & matlab.mixin.Copyable
                 if isempty(outputlayertype)
                     outputlayertype = "Classification";
                 end
+                if ~isMATLABReleaseOlderThan("R2020b")
+                    outputlayertype = lower(outputlayertype);
+                end
                 net = importONNXNetwork(filename, 'OutputLayerType', outputlayertype);
                 rmdir(directory, 's');
             end

--- a/braph2genesis/src/ds/_ETG.gen.m
+++ b/braph2genesis/src/ds/_ETG.gen.m
@@ -69,14 +69,14 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     pred = predict(etg.get('MODEL_SERIES'), img);
     pred_dec = predict(etg_dec.get('MODEL_SERIES'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from JSON.')
 
     pred = predict(etg.get('MODEL_DAG'), img);
     pred_dec = predict(etg_dec.get('MODEL_DAG'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from JSON.')
 
@@ -100,12 +100,11 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     size_y = 28;
     num_channel = 1;
     num_neuron = 100;
-    num_class = 10;
+    num_class = 1;
     layers = [
         imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel))
         fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y), 'Bias', rand(num_neuron, 1))
         fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron), 'Bias', rand(num_class, 1))
-        softmaxLayer('Name', 'softmax')
         regressionLayer('Name', 'regressOutput')
         ];
     net_series = SeriesNetwork(layers);
@@ -130,14 +129,14 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     pred = predict(etg.get('MODEL_SERIES'), img);
     pred_dec = predict(etg_dec.get('MODEL_SERIES'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from JSON.')
 
     pred = predict(etg.get('MODEL_DAG'), img);
     pred_dec = predict(etg_dec.get('MODEL_DAG'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from JSON.')
 
@@ -161,12 +160,11 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     size_y = 28;
     num_channel = 1;
     num_neuron = 100;
-    num_class = 10;
+    num_class = 1;
     layers = [
         imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel))
         fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y), 'Bias', rand(num_neuron, 1))
         fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron), 'Bias', rand(num_class, 1))
-        softmaxLayer('Name', 'softmax')
         regressionLayer('Name', 'regressOutput')
         ];
     net_series = SeriesNetwork(layers);
@@ -203,14 +201,14 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     pred = predict(etg.get('MODEL_SERIES'), img);
     pred_dec = predict(etg_dec.get('MODEL_SERIES'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from b2 file.')
 
     pred = predict(etg.get('MODEL_DAG'), img);
     pred_dec = predict(etg_dec.get('MODEL_DAG'), img);
 
-    assert(max(abs(pred - pred_dec)) < 1E-06, ...
+    assert(max(abs(pred - pred_dec)) < 1E-04, ...
         [BRAPH2.STR ':ETG:' BRAPH2.BUG_ERR], ...
         'Prediction is not being calculated correctly with the model from b2 file.')
 


### PR DESCRIPTION
This PR addresses the ONNX importing problem with MATLAB version R2020b for Windows OS.
Also, the complete test is done across 4 different versions, R2020b, R2021a, R2021b, R2022a.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/30530538/164885058-c3791aea-7693-498e-9cd4-d15c3d3986eb.png">

<img width="422" alt="image" src="https://user-images.githubusercontent.com/30530538/164826032-7b387338-e46b-4b84-950e-fe8ae0a64cdc.png">
<img width="401" alt="image" src="https://user-images.githubusercontent.com/30530538/164866094-992e4ea3-717b-45ed-8582-99f3d44837bb.png">
<img width="634" alt="image" src="https://user-images.githubusercontent.com/30530538/164872595-ed8a3d54-c1f5-45ea-b1a5-c1e006030c94.png">
<img width="443" alt="image" src="https://user-images.githubusercontent.com/30530538/164885051-014cc045-a273-46e0-bc51-950fe7f65bb1.png">

