### PR TITLE
1341 ywc etg test bug

### DIFF
--- a/braph2genesis/src/ds/_ETG.gen.m
+++ b/braph2genesis/src/ds/_ETG.gen.m
@@ -41,9 +41,9 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     num_neuron = 100;
     num_class = 10;
     layers = [
-        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel))
-        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y), 'Bias', rand(num_neuron, 1))
-        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron), 'Bias', rand(num_class, 1))
+        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel, 'single'))
+        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y, 'single'), 'Bias', rand(num_neuron, 1, 'single'))
+        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron, 'single'), 'Bias', rand(num_class, 1, 'single'))
         softmaxLayer('Name', 'softmax')
         classificationLayer('Classes', categorical(1:num_class), 'Name', 'classOutput')
         ];

--- a/braph2genesis/src/ds/_ETG.gen.m
+++ b/braph2genesis/src/ds/_ETG.gen.m
@@ -102,9 +102,9 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     num_neuron = 100;
     num_class = 1;
     layers = [
-        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel))
-        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y), 'Bias', rand(num_neuron, 1))
-        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron), 'Bias', rand(num_class, 1))
+        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel, 'single'))
+        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y, 'single'), 'Bias', rand(num_neuron, 1, 'single'))
+        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron, 'single'), 'Bias', rand(num_class, 1, 'single'))
         regressionLayer('Name', 'regressOutput')
         ];
     net_series = SeriesNetwork(layers);
@@ -162,9 +162,9 @@ if BRAPH2.installed('NN', 'warning') && BRAPH2.installed('ONNXCONVERTER', 'warni
     num_neuron = 100;
     num_class = 1;
     layers = [
-        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel))
-        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y), 'Bias', rand(num_neuron, 1))
-        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron), 'Bias', rand(num_class, 1))
+        imageInputLayer([size_x size_y num_channel], 'Name', 'input', 'Mean', rand(size_x, size_y, num_channel, 'single'))
+        fullyConnectedLayer(num_neuron, 'Name', 'fc1', 'Weights', rand(num_neuron, size_x * size_y, 'single'), 'Bias', rand(num_neuron, 1, 'single'))
+        fullyConnectedLayer(num_class, 'Name', 'fc2', 'Weights', rand(num_class, num_neuron, 'single'), 'Bias', rand(num_class, 1, 'single'))
         regressionLayer('Name', 'regressOutput')
         ];
     net_series = SeriesNetwork(layers);


### PR DESCRIPTION
This PR resolved the predicting error that happens in Linux and Mac but not in Windows.
The root cause is that, when using predict function for deep learning model, the precision of initialized weight array has to be specified as "single" instead of "double".
 
This PR has been tested with test_braph2
- [x] In _Windows_, R2021a
- [x] In _Linux_, R2021a
- [x] In _Windows_ R2020b
<img width="527" alt="image" src="https://user-images.githubusercontent.com/30530538/164992604-c4f78c82-7776-4d5b-876a-21f981557759.png">
<img width="658" alt="image" src="https://user-images.githubusercontent.com/30530538/164992631-e920e514-5ee2-40b0-b2a4-08eed3c73e7c.png">
