### PR TITLE
Randomize() for multigraphs and multiplexes with BUD/BUT

### DIFF
--- a/braph2genesis/graphs/_GraphWU.gen.m
+++ b/braph2genesis/graphs/_GraphWU.gen.m
@@ -202,9 +202,22 @@ function random_g = randomize(g)
     number_of_weights = g.get('NUMBEROFWEIGHTS');
     attempts_per_edge = g.get('ATTEMPTSPEREDGE');
 
-    A = cell2mat(g.get('A'));
-    random_A = GraphWU.randomize_A(A, attempts_per_edge, number_of_weights);
-    random_g = GraphWU('B', random_A);
+    % correction for multigraphs
+    if Graph.is_multigraph(g)
+        tmp_b = g.get('B');
+        tmp_g = GraphWU('B', tmp_b);
+        tmp_A = cell2mat(tmp_g.get('A'));
+        random_B = GraphWU.randomize_A(tmp_A, attempts_per_edge, number_of_weights);
+        if isa(g, 'MultigraphBUD')
+            random_g = MultigraphBUD('B', random_B, 'Densities', g.get('Densities'));
+        else
+            random_g = MultigraphBUT('B', random_B, 'Thresholds', g.get('Thresholds'));
+        end
+    else
+        A = cell2mat(g.get('A'));
+        random_A = GraphWU.randomize_A(A, attempts_per_edge, number_of_weights);
+        random_g = GraphWU('B', random_A);
+    end
 end
 
 %% ¡tests!

--- a/braph2genesis/graphs/_MultiplexWU.gen.m
+++ b/braph2genesis/graphs/_MultiplexWU.gen.m
@@ -128,37 +128,36 @@ function random_g = randomize(g)
         attempts_per_edge = 5;
     end
 
-    % get A
-    A = g.get('A');
-    L = g.layernumber();
-    random_multi_A = cell(1, L);
-
-    % special case for multiplexBUD and multiplexBUT
-    if Graph.is_binary(g)
-        tmp_b = g.get('B');
-        tmp_g = MultiplexWU('B', tmp_b);
-        tmp_A = tmp_g.get('A');
-        
-        for li = 1:1:L
-            Aii = tmp_A{li, li};
-            random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
-            random_multi_A(li) = {random_A};
-        end
-        if isa(g, 'MultiplexBUD')
-            random_g = MultiplexBUD('B', random_multi_A, 'Densities', g.get('Densities'));
-        else
-            random_g = MultiplexBUT('B', random_multi_A, 'Thresholds', g.get('Thresholds'));
-        end
-        
-    else % multiplexWU
-        
-        for li = 1:1:L
-            Aii = A{li, li};
-            random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
-            random_multi_A(li) = {random_A};
-        end
-        random_g = MultiplexWU('B', random_multi_A);
-    end
+            % get A
+            A = g.get('A');
+            [l, ls] = g.layernumber();
+              
+            % special case for multiplexBUD and multiplexBUT
+            if Graph.is_binary(g)
+                tmp_b = g.get('B');
+                tmp_g = MultiplexWU('B', tmp_b);
+                tmp_A = tmp_g.get('A');
+                random_multi_A = cell(1, ls(1));
+                for li = 1:1:ls(1)
+                    Aii = tmp_A{li, li};
+                    random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
+                    random_multi_A(li) = {random_A};
+                end
+                if isa(g, 'MultiplexBUD')
+                    random_g = MultiplexBUD('B', random_multi_A, 'Densities', g.get('Densities'));
+                else
+                    random_g = MultiplexBUT('B', random_multi_A, 'Thresholds', g.get('Thresholds'));
+                end
+                
+            else % multiplexWU
+                random_multi_A = cell(1, l);
+                for li = 1:1:l
+                    Aii = A{li, li};
+                    random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
+                    random_multi_A(li) = {random_A};
+                end
+                random_g = MultiplexWU('B', random_multi_A);
+            end
 end
 
 

--- a/braph2genesis/graphs/_MultiplexWU.gen.m
+++ b/braph2genesis/graphs/_MultiplexWU.gen.m
@@ -133,12 +133,32 @@ function random_g = randomize(g)
     L = g.layernumber();
     random_multi_A = cell(1, L);
 
-    for li = 1:1:L
-        Aii = A{li, li};
-        random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
-        random_multi_A(li) = {random_A};
+    % special case for multiplexBUD and multiplexBUT
+    if Graph.is_binary(g)
+        tmp_b = g.get('B');
+        tmp_g = MultiplexWU('B', tmp_b);
+        tmp_A = tmp_g.get('A');
+        
+        for li = 1:1:L
+            Aii = tmp_A{li, li};
+            random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
+            random_multi_A(li) = {random_A};
+        end
+        if isa(g, 'MultiplexBUD')
+            random_g = MultiplexBUD('B', random_multi_A, 'Densities', g.get('Densities'));
+        else
+            random_g = MultiplexBUT('B', random_multi_A, 'Thresholds', g.get('Thresholds'));
+        end
+        
+    else % multiplexWU
+        
+        for li = 1:1:L
+            Aii = A{li, li};
+            random_A = GraphWU.randomize_A(Aii, attempts_per_edge, number_of_weights);
+            random_multi_A(li) = {random_A};
+        end
+        random_g = MultiplexWU('B', random_multi_A);
     end
-    random_g = MultiplexWU('B', random_multi_A);
 end
 
 

--- a/braph2genesis/measures/_PathLength.gen.m
+++ b/braph2genesis/measures/_PathLength.gen.m
@@ -67,9 +67,8 @@ parfor li = 1:1:L
                 Du = distance_layer(:, u);
                 path_length_layer(u) = mean(Du(Du~=0));
             end
-    end
-    path_length_layer(isinf(path_length_layer)) = 0;  % node Inf corresponds to isolated nodes, pathlength is 0
-    path_length(li) = {path_length_layer};
+    end 
+    path_length(li) = {path_length_layer}; % node Inf corresponds to isolated nodes
 end
 value = path_length;
 

--- a/braph2genesis/measures/_PathLength.gen.m
+++ b/braph2genesis/measures/_PathLength.gen.m
@@ -56,8 +56,7 @@ parfor li = 1:1:L
             for u = 1:1:N
                 Du = distance_layer(:, u);
                 path_length_layer(u) = mean(Du(Du~=Inf & Du~=0));
-            end
-            path_length_layer(isnan(path_length_layer)) = 0;  % node Nan corresponds to isolated nodes, pathlength is 0
+            end 
         case {'harmonic'}
             for u = 1:1:N
                 Du = distance_layer(:, u);
@@ -69,6 +68,7 @@ parfor li = 1:1:L
                 path_length_layer(u) = mean(Du(Du~=0));
             end
     end
+    path_length_layer(isinf(path_length_layer)) = 0;  % node Inf corresponds to isolated nodes, pathlength is 0
     path_length(li) = {path_length_layer};
 end
 value = path_length;

--- a/braph2genesis/measures/_SmallWorldness.gen.m
+++ b/braph2genesis/measures/_SmallWorldness.gen.m
@@ -60,7 +60,7 @@ clustering_av_random = mean(clustering_av_random, 2);
 small_worldness = cell(L, 1);
 for li = 1:1:L
     small_worldness_layer = (clustering_av{li}/clustering_av_random(li)) / (path_length_av{li}/ path_length_av_random(li));
-    small_worldness_layer(isnan(small_worldness_layer)) = 1;  % node NaN corresponds to 0/0 or Inf/Inf from path length
+    small_worldness_layer(isnan(small_worldness_layer)) = 0;  % node NaN corresponds to 0/0 or Inf/Inf from path length (disconnected nodes)
     small_worldness(li) = {small_worldness_layer};
 end
 

--- a/braph2genesis/measures/_SmallWorldness.gen.m
+++ b/braph2genesis/measures/_SmallWorldness.gen.m
@@ -60,6 +60,7 @@ clustering_av_random = mean(clustering_av_random, 2);
 small_worldness = cell(L, 1);
 for li = 1:1:L
     small_worldness_layer = (clustering_av{li}/clustering_av_random(li)) / (path_length_av{li}/ path_length_av_random(li));
+    small_worldness_layer(isnan(small_worldness_layer)) = 1;  % node NaN corresponds to 0/0 or Inf/Inf from path length
     small_worldness(li) = {small_worldness_layer};
 end
 


### PR DESCRIPTION
It solves/implements the randomize function (needed for Smallworldness calculation) for: 

- [x] MultigraphBUD
- [x] MultigraphBUT
- [x] MultiplexBUD
- [x] MultiplexBUT