### PR TITLE
add spaces to descriptions of measures

### DIFF
--- a/braph2genesis/measures/_Assortativity.gen.m
+++ b/braph2genesis/measures/_Assortativity.gen.m
@@ -3,8 +3,8 @@ Assortativity < Measure (m, assortativity) is the graph assortativity.
 
 %%% ¡description!
 The assortativity coefficient of a graph is the correlation coefficient 
-between the degrees/strengths of all nodes on two opposite ends of an edge within a layer.
-The corresponding coefficient for directed and weighted networks is calculated
+between the degrees/strengths of all nodes on two opposite ends of an edge within a layer. 
+The corresponding coefficient for directed and weighted networks is calculated 
 by using the weighted and directed variants of degree/strength.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_BetweennessCentrality.gen.m
+++ b/braph2genesis/measures/_BetweennessCentrality.gen.m
@@ -3,7 +3,7 @@ BetweennessCentrality < Measure (m, betweenness centrality) is the graph between
 
 %%% ¡description!
 The betweenness centrality of a graph is the fraction of all shortest paths in the 
-graph that pass through a given node. Nodes with high values of betweenness
+graph that pass through a given node. Nodes with high values of betweenness 
 centrality participate in a large number of shortest paths.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_Clustering.gen.m
+++ b/braph2genesis/measures/_Clustering.gen.m
@@ -2,8 +2,8 @@
 Clustering < Triangles (m, clustering) is the graph clustering.
 
 %%% ¡description!
-The clustering coefficient of a node is the fraction of triangles present
-around a node. The clustering coefficient is calculated as the ratio between
+The clustering coefficient of a node is the fraction of triangles present 
+around a node. The clustering coefficient is calculated as the ratio between 
 the number of triangles present around a node and the maximum number of 
 triangles that could possibly be formed around that node.
 

--- a/braph2genesis/measures/_CommunityStructure.gen.m
+++ b/braph2genesis/measures/_CommunityStructure.gen.m
@@ -2,8 +2,8 @@
 CommunityStructure < Measure (m, community structure) is the graph community structure.
 
 %%% ¡description!
-The community structure of a graph is a subdivision of the network into
-non-overlapping groups of nodes which maximizes the number of whitin group
+The community structure of a graph is a subdivision of the network into 
+non-overlapping groups of nodes which maximizes the number of whitin group 
 edges, and minimizes the number of between group edges.
 
 %%% ¡seealso!

--- a/braph2genesis/measures/_EdgeNumberDistance.gen.m
+++ b/braph2genesis/measures/_EdgeNumberDistance.gen.m
@@ -2,7 +2,7 @@
 EdgeNumberDistance < Distance (m, edge number distance) is the graph edge number distance.
 
 %%% ¡description!
-The edge distance number of a graph is the number of edges in the shortest
+The edge distance number of a graph is the number of edges in the shortest 
 weighted path between two nodes within a layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_EdgeOverlap.gen.m
+++ b/braph2genesis/measures/_EdgeOverlap.gen.m
@@ -2,7 +2,7 @@
 EdgeOverlap < Measure (m, edge overlap) is the graph edge overlap.
 
 %%% ¡description!
-The edge overlap of a graph is the fraction of layers in which an edge between
+The edge overlap of a graph is the fraction of layers in which an edge between 
 a pair of nodes exists. Connection weights are ignored in calculations.
     
 %%% ¡shape!

--- a/braph2genesis/measures/_Flexibility.gen.m
+++ b/braph2genesis/measures/_Flexibility.gen.m
@@ -6,7 +6,7 @@ The flexibility of each node in a multilayer network is calculated
 as the number of times that it changes community assignment, 
 normalized by the total possible number of changes. In ordered 
 multilayer networks (e.g. temporal, changes are possible only between 
-adjacent layers, whereas in categorical multilayer networks,  
+adjacent layers, whereas in categorical multilayer networks, 
 community assignment changes are possible between any pairs of layers.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_GlobalEfficiency.gen.m
+++ b/braph2genesis/measures/_GlobalEfficiency.gen.m
@@ -2,7 +2,7 @@
 GlobalEfficiency < Measure (m, global efficiency) is the graph global efficiency.
 
 %%% ¡description!
-The global efficiency is the average inverse shortest path length within each layer.
+The global efficiency is the average inverse shortest path length within each layer. 
 It is inversely related to the characteristic path length.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_GlobalEfficiencyAv.gen.m
+++ b/braph2genesis/measures/_GlobalEfficiencyAv.gen.m
@@ -2,7 +2,7 @@
 GlobalEfficiencyAv < GlobalEfficiency (m, average global efficiency) is the graph average global efficiency.
 
 %%% ¡description!
-The average global efficiency is the average of the
+The average global efficiency is the average of the 
 global efficiency within each layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InDegree.gen.m
+++ b/braph2genesis/measures/_InDegree.gen.m
@@ -2,7 +2,7 @@
 InDegree < Measure (m, in-degree) is the graph in-degree.
 
 %%% ¡description!
-The in-degree of a node is the number of inward edges connected to a node within a layer.
+The in-degree of a node is the number of inward edges connected to a node within a layer. 
 Connection weights are ignored in calculations.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InGlobalEfficiencyAv.gen.m
+++ b/braph2genesis/measures/_InGlobalEfficiencyAv.gen.m
@@ -2,7 +2,7 @@
 InGlobalEfficiencyAv < InGlobalEfficiency (m, average in-global efficiency) is the graph average in-global efficiency.
 
 %%% ¡description!
-The average in-global efficiency is the average of the in-global efficiency
+The average in-global efficiency is the average of the in-global efficiency 
 within each layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InInAssortativity.gen.m
+++ b/braph2genesis/measures/_InInAssortativity.gen.m
@@ -2,9 +2,9 @@
 InInAssortativity < Measure (m, in-in-assortativity) is the graph in-in-assortativity.
 
 %%% ¡description!
-The in-in-assortativity coefficient of a graph is the correlation coefficient between
-the degrees/strengths of all nodes on two opposite ends of an edge within a layer.
-The corresponding coefficient for directed and weighted networks is calculated by
+The in-in-assortativity coefficient of a graph is the correlation coefficient between 
+the degrees/strengths of all nodes on two opposite ends of an edge within a layer. 
+The corresponding coefficient for directed and weighted networks is calculated by 
 using the weighted and directed variants of in-degree/in-strength.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InOutAssortativity.gen.m
+++ b/braph2genesis/measures/_InOutAssortativity.gen.m
@@ -2,9 +2,9 @@
 InOutAssortativity < Measure (m, InOutAssortativity) is the graph in-out-assortativity.
 
 %%% ¡description!
-The in-out-assortativity coefficient of a graph is the correlation coefficient between
-the degrees/strengths of all nodes on two opposite ends of an edge within a layer.
-The corresponding coefficient for directed and weighted networks is calculated by
+The in-out-assortativity coefficient of a graph is the correlation coefficient between 
+the degrees/strengths of all nodes on two opposite ends of an edge within a layer. 
+The corresponding coefficient for directed and weighted networks is calculated by 
 using the weighted and directed variants of in-out-degree/in-out-strength.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InPathLength.gen.m
+++ b/braph2genesis/measures/_InPathLength.gen.m
@@ -2,7 +2,7 @@
 InPathLength < Measure (m, in-path length) is the graph in-path length.
 
 %%% ¡description!
-The in-path length is the average shortest in-path length of one
+The in-path length is the average shortest in-path length of one 
 node to all other nodes within a layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_InStrengthAv.gen.m
+++ b/braph2genesis/measures/_InStrengthAv.gen.m
@@ -2,7 +2,7 @@
 InStrengthAv < InStrength (m, average in-strength) is the graph average in-strength.
 
 %%% ¡description!
-The average in-strength of a graph is the average of the sum of all weights of
+The average in-strength of a graph is the average of the sum of all weights of 
 the inward edges connected to a node within a layer. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_KCorenessCentrality.gen.m
+++ b/braph2genesis/measures/_KCorenessCentrality.gen.m
@@ -2,7 +2,7 @@
 KCorenessCentrality < Measure (m, k-coreness centrality) is the graph k-coreness centrality.
 
 %%% ¡description!
-The k-coreness centrality of a node is k if the node belongs to the k-core
+The k-coreness centrality of a node is k if the node belongs to the k-core 
 but not to the (k+1)-core.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_LocalEfficiencyAv.gen.m
+++ b/braph2genesis/measures/_LocalEfficiencyAv.gen.m
@@ -2,7 +2,7 @@
 LocalEfficiencyAv < LocalEfficiency (m, average local efficiency) is the graph average local efficiency.
 
 %%% ¡description!
-The average local efficiency is the average of all the local efficiencies
+The average local efficiency is the average of all the local efficiencies 
 within each layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_MultiRichClubStrength.gen.m
+++ b/braph2genesis/measures/_MultiRichClubStrength.gen.m
@@ -2,8 +2,8 @@
 MultiRichClubStrength < RichClubStrength (m, multi rich-club strength) is the graph multi rich-club strength.
 
 %%% ¡description!
-The multi rich-club strength of a node at level s is the sum of the
-weighted edges that connect nodes of strength s or higher in all layers.
+The multi rich-club strength of a node at level s is the sum of the 
+weighted edges that connect nodes of strength s or higher in all layers. 
 The relevance of each layer is controlled by the coefficients c that are 
 between 0 and 1; the default coefficients are (1/layernumber).
 

--- a/braph2genesis/measures/_MultiplexClustering.gen.m
+++ b/braph2genesis/measures/_MultiplexClustering.gen.m
@@ -2,7 +2,7 @@
 MultiplexClustering < MultiplexTriangles (m, multiplex clustering) is the graph multiplex clustering.
 
 %%% ¡description!
-The two-multiplex clustering coefficient of a node i is the fraction
+The two-multiplex clustering coefficient of a node i is the fraction 
 of two-multiplex triangles (triangles which use edges from two different 
 layers) with a vertex in node i and the number of one-triads centered in i.
       

--- a/braph2genesis/measures/_MultiplexKCorenessCentrality.gen.m
+++ b/braph2genesis/measures/_MultiplexKCorenessCentrality.gen.m
@@ -2,7 +2,7 @@
 MultiplexKCorenessCentrality < Measure (m, multiplex k-coreness centrality) is the graph multiplex k-coreness centrality.
 
 %%% ¡description!
-The multiplex k-coreness centrality of a node is k if the node belongs to the k-core
+The multiplex k-coreness centrality of a node is k if the node belongs to the k-core 
 but not to the (k+1)-core.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_MultiplexParticipation.gen.m
+++ b/braph2genesis/measures/_MultiplexParticipation.gen.m
@@ -3,11 +3,11 @@ MultiplexParticipation < Measure (m, multiplex participation) is the graph multi
 
 %%% ¡description!
 The multiplex participation is the nodal homogeneity of the number of 
-neighbours of a node across the layers.
-It is calculated as: Pi = L/(L - 1) [1 - sum_{l=1}^{L} (ki(l)/oi)^2]
-where L is the number of layers, ki(l) is the degree in the l-th
-layer and oi is the overlapping degree of the node.
-Pi = 1 when the degree is the same in all layers and Pi = 0 when a
+neighbours of a node across the layers. 
+It is calculated as: Pi = L/(L - 1) [1 - sum_{l=1}^{L} (ki(l)/oi)^2] 
+where L is the number of layers, ki(l) is the degree in the l-th 
+layer and oi is the overlapping degree of the node. 
+Pi = 1 when the degree is the same in all layers and Pi = 0 when a 
 node has non-zero degree in only one layer.
     
 %%% ¡shape!

--- a/braph2genesis/measures/_MultiplexParticipationAv.gen.m
+++ b/braph2genesis/measures/_MultiplexParticipationAv.gen.m
@@ -2,7 +2,7 @@
 MultiplexParticipationAv < MultiplexParticipation (m, average multiplex participation) is the graph average multiplex participation.
 
 %%% ¡description!
-The average multiplex participation of a graph is the average homogeneity
+The average multiplex participation of a graph is the average homogeneity 
 of its number of neighbours across the layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_MultiplexTriangles.gen.m
+++ b/braph2genesis/measures/_MultiplexTriangles.gen.m
@@ -2,7 +2,7 @@
 MultiplexTriangles < Measure (m, multiplex triangles) is the graph multiplex triangles.
 
 %%% ¡description!
-The multiplex triangles are calculated as the number of neighbors of a node
+The multiplex triangles are calculated as the number of neighbors of a node 
 that are also neighbors of each other between each pair of layers. 
 In weighted graphs, the multiplex triangles are calculated as geometric mean 
 of the weights of the edges forming the multiplex triangle.

--- a/braph2genesis/measures/_Multirichness.gen.m
+++ b/braph2genesis/measures/_Multirichness.gen.m
@@ -2,7 +2,7 @@
 Multirichness < Richness (m, multirichness) is the graph multirichness.
 
 %%% ¡description!
-The multirichness of a node is the sum of the edges that connect nodes
+The multirichness of a node is the sum of the edges that connect nodes 
 of degree k or higher in all layers. The relevance of each layer is 
 controlled by the coefficients c that are between 0 and 1; 
 the default coefficients are (1/layernumber).

--- a/braph2genesis/measures/_OutGlobalEfficiencyAv.gen.m
+++ b/braph2genesis/measures/_OutGlobalEfficiencyAv.gen.m
@@ -2,7 +2,7 @@
 OutGlobalEfficiencyAv < OutGlobalEfficiency (m, average out-global efficiency) is the graph average out-global efficiency.
 
 %%% ¡description!
-The average out-global efficiency is the average of the out-global efficiency
+The average out-global efficiency is the average of the out-global efficiency 
 without each layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OutInAssortativity.gen.m
+++ b/braph2genesis/measures/_OutInAssortativity.gen.m
@@ -3,8 +3,8 @@ OutInAssortativity < Measure (m, out-in-assortativity) is the graph out-in-assor
 
 %%% ¡description!
 The out-in-assortativity coefficient of a graph is the correlation coefficient between 
-the degrees/strengths of all nodes on two opposite ends of an edge within a layer.
-The corresponding coefficient for directed and weighted networks is calculated by
+the degrees/strengths of all nodes on two opposite ends of an edge within a layer. 
+The corresponding coefficient for directed and weighted networks is calculated by 
 using the weighted and directed variants of in-out-degree/in-out-strength.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OutOutAssortativity.gen.m
+++ b/braph2genesis/measures/_OutOutAssortativity.gen.m
@@ -2,9 +2,9 @@
 OutOutAssortativity < Measure (m, out-out-assortativity) is the graph out-out-assortativity.
 
 %%% ¡description!
-The out-out-assortativity coefficient of a graph is the correlation coefficient between
-the degrees/strengths of all nodes on two opposite ends of an edge within a layer.
-The corresponding coefficient for directed and weighted networks is calculated by using
+The out-out-assortativity coefficient of a graph is the correlation coefficient between 
+the degrees/strengths of all nodes on two opposite ends of an edge within a layer. 
+The corresponding coefficient for directed and weighted networks is calculated by using 
 the weighted and directed variants of out-degree/out-strength.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OutPathLength.gen.m
+++ b/braph2genesis/measures/_OutPathLength.gen.m
@@ -2,7 +2,7 @@
 OutPathLength < Measure (m, out-path length) is the graph out-path length.
 
 %%% ¡description!
-The out-path length is the average shortest out-path lengths of one
+The out-path length is the average shortest out-path lengths of one 
 node to all other nodes without a layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OutPathLengthAv.gen.m
+++ b/braph2genesis/measures/_OutPathLengthAv.gen.m
@@ -2,7 +2,7 @@
 OutPathLengthAv < OutPathLength (m, average out-path length) is the graph average out-path length.
 
 %%% ¡description!
-The average out-path length of a graph is the average of the sum of the
+The average out-path length of a graph is the average of the sum of the 
 out-path lengths within each layer. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OutStrengthAv.gen.m
+++ b/braph2genesis/measures/_OutStrengthAv.gen.m
@@ -2,7 +2,7 @@
 OutStrengthAv < OutStrength (m, average out-strength) is the graph average out-strength.
 
 %%% ¡description!
-The average out-strength of a graph is the average of the sum of all weights of
+The average out-strength of a graph is the average of the sum of all weights of 
 the outward edges connected to a node within a layer. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OverlappingDegree.gen.m
+++ b/braph2genesis/measures/_OverlappingDegree.gen.m
@@ -2,7 +2,7 @@
 OverlappingDegree < Degree (m, overlapping degree) is the graph overlapping degree.
 
 %%% ¡description!
-The overlapping degree of a graph is the sum of the degrees of a node in
+The overlapping degree of a graph is the sum of the degrees of a node in 
 all layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_OverlappingStrength.gen.m
+++ b/braph2genesis/measures/_OverlappingStrength.gen.m
@@ -2,7 +2,7 @@
 OverlappingStrength < Strength (m, overlapping strength) is the graph overlapping strength.
 
 %%% ¡description!
-The overlapping strength of a graph is the sum of the strengths of a node in
+The overlapping strength of a graph is the sum of the strengths of a node in 
 all layers. 
   
 %%% ¡shape!

--- a/braph2genesis/measures/_Participation.gen.m
+++ b/braph2genesis/measures/_Participation.gen.m
@@ -2,7 +2,7 @@
 Participation < Measure (m, participation) is the graph participation.
 
 %%% ¡description!
-The participation of a node is the ratio of edges that a node forms within
+The participation of a node is the ratio of edges that a node forms within 
 a single layer community to the total number of edges that forms within the whole single layer graph.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_PathLength.gen.m
+++ b/braph2genesis/measures/_PathLength.gen.m
@@ -2,7 +2,7 @@
 PathLength < Measure (m, path length) is the graph path length.
 
 %%% ¡description!
-The path length is the average shortest path length of one node to all
+The path length is the average shortest path length of one node to all 
 other nodes within a layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_PathLengthAv.gen.m
+++ b/braph2genesis/measures/_PathLengthAv.gen.m
@@ -2,7 +2,7 @@
 PathLengthAv < PathLength (m, average path length) is the graph average path length.
 
 %%% ¡description!
-The average path length of a graph is the average of the sum of
+The average path length of a graph is the average of the sum of 
 the path lengths within each layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_Persistence.gen.m
+++ b/braph2genesis/measures/_Persistence.gen.m
@@ -4,8 +4,8 @@ Persistence < MultilayerCommunityStructure (m, persistence) is the graph persist
 %%% ¡description!
 The persistence of a multilayer network is calculated as the normalized 
 sum of the number of nodes that do not change community assignments. It 
-varies between 0 and 1.
-In categorical multilayer networks, it is the sum over all pairs of layers
+varies between 0 and 1. 
+In categorical multilayer networks, it is the sum over all pairs of layers 
 of the number of nodes that do not change community assignments, whereas 
 in ordinal multilayer networks (e.g. temporal), it is the number of nodes 
 that do not change community assignments between consecutive layers.

--- a/braph2genesis/measures/_RichClub.gen.m
+++ b/braph2genesis/measures/_RichClub.gen.m
@@ -3,8 +3,8 @@ RichClub < Degree (m, rich-club) is the graph rich-club coefficient.
 
 %%% ¡description!
 The rich-club coefficient of a node at level k is the fraction of 
-the edges that connect nodes of degree k or higher out of the
-maxium number of edges that such nodes might share within a
+the edges that connect nodes of degree k or higher out of the 
+maxium number of edges that such nodes might share within a 
 layer. k is set by the user, the default value is equal to 1.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_RichClubStrength.gen.m
+++ b/braph2genesis/measures/_RichClubStrength.gen.m
@@ -3,8 +3,8 @@ RichClubStrength < Strength (m, rich-club strength) is the graph rich-club stren
 
 %%% ¡description!
 The rich-club strength of a node at level s is the sum of the weighted edges 
-that connect nodes of strength s or higher within a layer.
-s is set by the user and it can be a vector containting all the strength thresholds
+that connect nodes of strength s or higher within a layer. 
+s is set by the user and it can be a vector containting all the strength thresholds 
 the default value is equal to 1.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_Richness.gen.m
+++ b/braph2genesis/measures/_Richness.gen.m
@@ -2,7 +2,7 @@
 Richness < Degree (m, richness) is the graph richness.
 
 %%% ¡description!
-The richness of a node is the sum of the edges that connect nodes
+The richness of a node is the sum of the edges that connect nodes 
 of higher degree within a layer.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_SCore.gen.m
+++ b/braph2genesis/measures/_SCore.gen.m
@@ -2,7 +2,7 @@
 SCore < Measure (m, s-core) is the graph s-core.
 
 %%% ¡description!
-The s-core of a graph is the largest subnetwork comprising nodes of strength
+The s-core of a graph is the largest subnetwork comprising nodes of strength 
 s or higher. s is set by the user; the default value is equal to 1.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_SmallWorldness.gen.m
+++ b/braph2genesis/measures/_SmallWorldness.gen.m
@@ -3,7 +3,7 @@ SmallWorldness < PathLengthAv (m, small-worldness) is the graph small-worldness.
 
 %%% ¡description!
 The small-worldness coefficient is the fraction of the clustering coefficient 
-and average path length of each layer and the clustering coefficient and
+and average path length of each layer and the clustering coefficient and 
 average path length of 100 random graphs.
 
 %%% ¡shape!

--- a/braph2genesis/measures/_Strength.gen.m
+++ b/braph2genesis/measures/_Strength.gen.m
@@ -2,7 +2,7 @@
 Strength < Measure (m, strength) is the graph strength.
 
 %%% ¡description!
-The strength of a graph is the sum of all weights of the edges connected to
+The strength of a graph is the sum of all weights of the edges connected to 
 a node within a layer. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_StrengthAv.gen.m
+++ b/braph2genesis/measures/_StrengthAv.gen.m
@@ -2,7 +2,7 @@
 StrengthAv < Strength (m, average strength) is the graph average strength.
 
 %%% ¡description!
-The average strength of a graph is the average of the sum of all weights of
+The average strength of a graph is the average of the sum of all weights of 
 the edges connected to a node within a layer. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_Triangles.gen.m
+++ b/braph2genesis/measures/_Triangles.gen.m
@@ -3,7 +3,7 @@ Triangles < Measure (m, triangles) is the graph triangles.
 
 %%% ¡description!
 The triangles are calculated as the number of neighbors of a node that are 
-also neighbors of each other within a layer. In weighted graphs, the triangles are
+also neighbors of each other within a layer. In weighted graphs, the triangles are 
 calculated as geometric mean of the weights of the edges forming the triangle.
 
 %%% ¡seealso!

--- a/braph2genesis/measures/_WeightedMultiplexInParticipation.gen.m
+++ b/braph2genesis/measures/_WeightedMultiplexInParticipation.gen.m
@@ -2,7 +2,7 @@
 WeightedMultiplexInParticipation < Measure (m, weighted multiplex in-participation) is the graph weighted multiplex in-participation.
 
 %%% ¡description!
-The weighted multiplex in-participation of a graph is the nodal homogeneity
+The weighted multiplex in-participation of a graph is the nodal homogeneity 
 of its number of inward neighbours across the layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_WeightedMultiplexOutParticipation.gen.m
+++ b/braph2genesis/measures/_WeightedMultiplexOutParticipation.gen.m
@@ -2,7 +2,7 @@
 WeightedMultiplexOutParticipation < Measure (m, weighted multiplex out-participation) is the graph weighted multiplex out-participation.
 
 %%% ¡description!
-The weighted multiplex out-participation of a graph is the nodal homogeneity
+The weighted multiplex out-participation of a graph is the nodal homogeneity 
 of its number of outward neighbours across the layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_WeightedMultiplexParticipation.gen.m
+++ b/braph2genesis/measures/_WeightedMultiplexParticipation.gen.m
@@ -2,7 +2,7 @@
 WeightedMultiplexParticipation < Measure (m, weighted multiplex participation) is the graph weighted multiplex participation.
 
 %%% ¡description!
-The weighted multiplex participation of a graph is the nodal homogeneity
+The weighted multiplex participation of a graph is the nodal homogeneity 
 of its number of neighbours across the layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_WeightedMultiplexParticipationAv.gen.m
+++ b/braph2genesis/measures/_WeightedMultiplexParticipationAv.gen.m
@@ -2,7 +2,7 @@
 WeightedMultiplexParticipationAv < WeightedMultiplexParticipation (m, average weighted multiplex participation) is the graph average weighted multiplex participation.
 
 %%% ¡description!
-The average weighted multiplex participation of a graph is the average homogeneity
+The average weighted multiplex participation of a graph is the average homogeneity 
 of its number of neighbours across the layers. 
 
 %%% ¡shape!

--- a/braph2genesis/measures/_WeightedRichClub.gen.m
+++ b/braph2genesis/measures/_WeightedRichClub.gen.m
@@ -2,9 +2,9 @@
 WeightedRichClub < Strength (m, weighted rich-club) is the graph weighted rich-club coefficient.
 
 %%% ¡description!
-The weighted rich-club coefficient of a node at level s is the fraction of the
+The weighted rich-club coefficient of a node at level s is the fraction of the 
 edges weights that connect nodes of strength s or higher out of the 
-maxium number of edges weights that such nodes might share within a layer.
+maxium number of edges weights that such nodes might share within a layer. 
 s is set by the user and it can be a vector containting all the 
 strength thresholds; the default value is equal to 1.
 


### PR DESCRIPTION
Add spaces after the end of the line in descriptions of measures, so that in the table of GRAPH MEASURES the description can be read properly.