### PR TITLE
Update height of IdictTable panel prop according to OS system

### DIFF
--- a/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
+++ b/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
@@ -95,7 +95,12 @@ if value
         pr.set('HEIGHT', s(2))
     else
         dict = el.get(prop);
-        pr.set('HEIGHT', min(s(4.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))
+        if ispc
+            pr.set('HEIGHT', min(s(6.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))
+        else
+            pr.set('HEIGHT', min(s(4.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))
+        end
+        
     end
 
     switch el.getPropCategory(prop)

--- a/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
+++ b/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
@@ -100,7 +100,6 @@ if value
         else
             pr.set('HEIGHT', min(s(4.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))
         end
-        
     end
 
     switch el.getPropCategory(prop)

--- a/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
+++ b/braph2genesis/src/gui/_PanelPropIDictTable.gen.m
@@ -95,7 +95,7 @@ if value
         pr.set('HEIGHT', s(2))
     else
         dict = el.get(prop);
-        if ispc
+        if ispc()
             pr.set('HEIGHT', min(s(6.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))
         else
             pr.set('HEIGHT', min(s(4.5) + s(2) * dict.get('LENGTH'), pr.get('TABLE_HEIGHT')))


### PR DESCRIPTION
As titled, so the table height looks good in windows
<img width="689" alt="image" src="https://github.com/braph-software/BRAPH-2/assets/30530538/c11106ef-07b3-4d9d-bf8a-ff84ca2b0c8f">
