### PR TITLE
Fix for neural networks (one-hot-encode and fold-splitting)

### DIFF
--- a/braph2genesis/neuralnetworks/_NNClassifierMLP.gen.m
+++ b/braph2genesis/neuralnetworks/_NNClassifierMLP.gen.m
@@ -189,7 +189,8 @@ end
 d = varargin{1};
 
 targets = cellfun(@(target) cell2mat(target),  d.get('TARGETS'), 'UniformOutput', false);
-value = onehotencode(categorical(cell2mat(targets))', 2);
+targets = categorical(cell2mat(targets))';
+value = onehotencode(targets, 2, "ClassNames", flip(string(unique(targets))));
 
 %%% ¡prop!
 MODEL (result, net) is a trained neural network model.

--- a/braph2genesis/src/nn/_NNCrossValidation.gen.m
+++ b/braph2genesis/src/nn/_NNCrossValidation.gen.m
@@ -97,8 +97,17 @@ DSP (result, itemlist) is a list of dataset splitter that splits the dataset per
 'NNDatasetSplit'
 %%%% ¡calculate!
 d_list = nncv.get('D');
-value = cellfun(@(d) NNDatasetSplit('D', d, 'SPLIT', nncv.get('SPLIT')), d_list, 'UniformOutput', false);
+split = nncv.get('SPLIT');
+if isempty(split)
+    split_per_dataset = {};
+else
+    for i = 1:length(d_list)
+        split_per_dataset{i} = split(i, :);
+    end
+end
 
+value = cellfun(@(d, s) NNDatasetSplit('D', d, 'SPLIT', s), d_list, split_per_dataset, 'UniformOutput', false);
+					
 %%% ¡prop!
 DCO (result, itemlist) is a list of dataset combiners that combines the datasets per fold.
 %%%% ¡settings!


### PR DESCRIPTION
This PR fixes bugs related to neural networks, specifically:

- _NNClassifierMLP_ (one-hot-encode functionality): Resolved the mismatch for classes.
- _NNCrossValidation_ (fold-splitting functionality): Enhanced to handle splitting with specified indexes for each fold.