### PR TITLE
Update for Element.m (save function for large MAT-files)

### DIFF
--- a/braph2genesis/src/ds/Element.m
+++ b/braph2genesis/src/ds/Element.m
@@ -1880,7 +1880,7 @@ classdef Element < Category & Format & matlab.mixin.Copyable
                 matlab_version = ver('MATLAB').Version;
                 matlab_version_details = ver();
                 build_log = load('build_log.mat', '-mat');  % % % double-check
-                save(filename, 'el', 'build', 'matlab_version', 'matlab_version_details', 'build_log');  % % % double-check
+                save(filename, 'el', 'build', 'matlab_version', 'matlab_version_details', 'build_log', '-v7.3');  % % % double-check
                 
                 saved = true;
                 


### PR DESCRIPTION
This PR adds '-v7.3' tag in save function, line 1858 in Element.m. This tag specifies the version of the MAT-file to be v7.3 rather than v7 (default).

The main difference between v7.3 and v7 is the Maximum Size of Each Variable.

v7.3 allows the Maximum Size of Each Variable to be more than 2 GB, which might be the case for some b2 files.

For more official information about this tag and save function, visit https://www.mathworks.com/help/matlab/ref/save.html.