### PR TITLE
Fix for typo and warnings

### DIFF
--- a/braph2/measures/Participation.m
+++ b/braph2/measures/Participation.m
@@ -582,7 +582,7 @@ classdef Participation < Measure
 				case 11 % Participation.PARAMETRICITY
 					prop_default = 2;
 				case 12 % Participation.COMPATIBLE_GRAPHS
-					prop_default = {'GraphBD' 'GraphBU' 'MultigraphBUT' 'MultiplexBU'};;
+					prop_default = {'GraphWU' 'GraphWD' 'GraphBD' 'GraphBU' 'MultigraphBUT' 'MultigraphBUD' 'MultiplexWU' 'MultiplexWD' 'MultiplexBU' 'MultiplexBD' 'MultiplexBUT' 'MultiplexBUD'};;
 				otherwise
 					prop_default = getPropDefault@Measure(prop);
 			end
@@ -709,7 +709,9 @@ classdef Participation < Measure
 					    connectivity_layer = connectivity_type(li, li);
 					    directionality_layer = directionality_type(li, li);
 					    Aii = A{li, li};
-					    m.set('CI', cell2mat(S));
+					    if ~isequal(m.get('CI'), cell2mat(S))
+					        m.set('CI', cell2mat(S));
+					    end
 					   
 					    if connectivity_layer == 1  % weighted graphs
 					        if directionality_layer == 2  % undirected graphs

--- a/braph2/measures/Participation.m
+++ b/braph2/measures/Participation.m
@@ -582,7 +582,7 @@ classdef Participation < Measure
 				case 11 % Participation.PARAMETRICITY
 					prop_default = 2;
 				case 12 % Participation.COMPATIBLE_GRAPHS
-					prop_default = {'GraphWU' 'GraphWD' 'GraphBD' 'GraphBU' 'MultigraphBUT' 'MultigraphBUD' 'MultiplexWU' 'MultiplexWD' 'MultiplexBU' 'MultiplexBD' 'MultiplexBUT' 'MultiplexBUD'};;
+					prop_default = {'GraphBD' 'GraphBU' 'MultigraphBUT' 'MultiplexBU'};;
 				otherwise
 					prop_default = getPropDefault@Measure(prop);
 			end
@@ -709,9 +709,7 @@ classdef Participation < Measure
 					    connectivity_layer = connectivity_type(li, li);
 					    directionality_layer = directionality_type(li, li);
 					    Aii = A{li, li};
-					    if ~isequal(m.get('CI'), cell2mat(S))
-					        m.set('CI', cell2mat(S));
-					    end
+					    m.set('CI', cell2mat(S));
 					   
 					    if connectivity_layer == 1  % weighted graphs
 					        if directionality_layer == 2  % undirected graphs

--- a/braph2genesis/measures/_CorePeriphery.gen.m
+++ b/braph2genesis/measures/_CorePeriphery.gen.m
@@ -158,7 +158,7 @@ else
         
         [~, rankingInd] = sort(deg, 'descend');
         richness_partition = richness{li};
-        [~, rankOfMaxRichness] = max(richness_partition(rankingInd));  
+        [~, rankOfMaxRichness] = max(richness_partition(rankingInd), [], 'all');  
         core_periphery_partition(rankingInd(1:rankOfMaxRichness)) = 1;
         core_periphery(li) = {core_periphery_partition};
     end

--- a/braph2genesis/measures/_MultiplexCP.gen.m
+++ b/braph2genesis/measures/_MultiplexCP.gen.m
@@ -187,7 +187,7 @@ else
         end
         [~, rankingInd] = sort(overlapping_coefficients, 'descend');
         multirichness_partition = multirichness{i};
-        [~, rankOfMaxMultiRCness] = max(multirichness_partition(rankingInd));  
+        [~, rankOfMaxMultiRCness] = max(multirichness_partition(rankingInd), [], 'all');  
         multiplex_core_periphery_partition(rankingInd(1:rankOfMaxMultiRCness)) = 1;
         count = count + ls(i);
         multiplex_core_periphery(i) = {multiplex_core_periphery_partition};

--- a/braph2genesis/measures/_Participation.gen.m
+++ b/braph2genesis/measures/_Participation.gen.m
@@ -131,7 +131,9 @@ for li = 1:1:L
     connectivity_layer = connectivity_type(li, li);
     directionality_layer = directionality_type(li, li);
     Aii = A{li, li};
-    m.set('CI', cell2mat(S));
+    if ~isequal(m.get('CI'), cell2mat(S))
+        m.set('CI', cell2mat(S));
+    end
    
     if connectivity_layer == Graph.WEIGHTED  % weighted graphs
         if directionality_layer == Graph.UNDIRECTED  % undirected graphs

--- a/braph2genesis/neuralnetworks/_NNDataPoint_Graph_REG.gen.m
+++ b/braph2genesis/neuralnetworks/_NNDataPoint_Graph_REG.gen.m
@@ -219,7 +219,7 @@ Construct the data point with the adjacency matrix derived from its multiplex we
 %%%% ¡code!
 % ensure the example data is generated
 if ~isfile([fileparts(which('NNDataPoint_CON_FUN_MP_REG')) filesep 'Example data NN REG CON_FUN_MP XLS' filesep 'atlas.xlsx'])
-    create_data_NN_REG_CON_FUN_MP_XSL() % create example files
+    create_data_NN_REG_CON_FUN_MP_XLS() % create example files
 end
 
 % Load BrainAtlas
@@ -310,7 +310,7 @@ example_NNCV_CON_BUT_REG
 Example script for binary undirected multiplex at fixed densities (MultiplexBUD) using connectivity data and functional data
 %%%% ¡code!
 if ~isfile([fileparts(which('NNDataPoint_CON_FUN_MP_REG')) filesep 'Example data NN REG CON_FUN_MP XLS' filesep 'atlas.xlsx'])
-    create_data_NN_REG_CON_FUN_MP_XSL() % create example files
+    create_data_NN_REG_CON_FUN_MP_XLS() % create example files
 end
 example_NNCV_CON_FUN_MP_BUD_REG
 
@@ -319,7 +319,7 @@ example_NNCV_CON_FUN_MP_BUD_REG
 Example script for binary undirected multiplex at fixed thresholds (MultiplexBUT) using connectivity data and functional data
 %%%% ¡code!
 if ~isfile([fileparts(which('NNDataPoint_CON_FUN_MP_REG')) filesep 'Example data NN REG CON_FUN_MP XLS' filesep 'atlas.xlsx'])
-    create_data_NN_REG_CON_FUN_MP_XSL % create example files
+    create_data_NN_REG_CON_FUN_MP_XLS % create example files
 end
 example_NNCV_CON_FUN_MP_BUT_REG
 

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportance.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportance.gen.m
@@ -446,7 +446,7 @@ end
 value = flattened_input;
 
 %%% ¡prop!
-VERBOSE (metadata, logical) is an indicator to display permutation progress information.
+VERBOSE (gui, logical) is an indicator to display permutation progress information.
 %%%% ¡default!
 false
 
@@ -654,7 +654,7 @@ nn = NNClassifierMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportance('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', true, 'APPLY_CONFIDENCE_INTERVALS', true, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportance('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', true, 'APPLY_CONFIDENCE_INTERVALS', true);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_dp = it_list1{1}.get('INPUT');
 
@@ -717,7 +717,7 @@ nn = NNRegressorMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportance('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', true, 'APPLY_CONFIDENCE_INTERVALS', true, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportance('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', true, 'APPLY_CONFIDENCE_INTERVALS', true);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_dp = it_list{1}.get('INPUT');
 

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceAcrossMeasures.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceAcrossMeasures.gen.m
@@ -407,7 +407,7 @@ nn = NNClassifierMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportanceAcrossMeasures('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceAcrossMeasures('D', d_test, 'NN', nn, 'P', 5, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_measure = it_list1{1}.get('M_LIST');
 

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceAcrossMeasures_CV.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceAcrossMeasures_CV.gen.m
@@ -335,8 +335,8 @@ nncv = NNClassifierMLP_CrossValidation('D', {d1, d2, d3}, 'KFOLDS', 2);
 nncv.get('TRAIN');
 
 % Evaluate the feature importance
-fi_template = NNxMLP_FeatureImportanceAcrossMeasures('P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
-fi_cv = NNxMLP_FeatureImportanceAcrossMeasures_CV('NNCV', nncv, 'FI_TEMPLATE', fi_template, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi_template = NNxMLP_FeatureImportanceAcrossMeasures('P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
+fi_cv = NNxMLP_FeatureImportanceAcrossMeasures_CV('NNCV', nncv, 'FI_TEMPLATE', fi_template, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 fi_score_cv = fi_cv.get('RESHAPED_AV_FEATURE_IMPORTANCE');
 input_measure = it_list1{1}.get('M_LIST');
 

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceBrainSurface.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceBrainSurface.gen.m
@@ -340,7 +340,7 @@ nn = NNClassifierMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_measure = it_list1{1}.get('INPUT');
 
@@ -352,7 +352,7 @@ for i = 1:length(input_measure)
 end
 
 % Test GUI
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 gui = GUIElement('PE', fi, 'CLOSEREQ', false);
 gui.get('DRAW')
 gui.get('SHOW')
@@ -466,7 +466,7 @@ nn = NNClassifierMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_measure = it_list1{1}.get('INPUT');
 
@@ -478,7 +478,7 @@ for i = 1:length(input_measure)
 end
 
 % Test GUI
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 gui = GUIElement('PE', fi, 'CLOSEREQ', false);
 gui.get('DRAW')
 gui.get('SHOW')
@@ -660,7 +660,7 @@ nn = NNClassifierMLP('D', d_training, 'LAYERS', [20 20]);
 nn.get('TRAIN');
 
 % Evaluate the feature importance
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 fi_score = fi.get('RESHAPED_FEATURE_IMPORTANCE');
 input_graph = it_list1{1}.get('INPUT');
 
@@ -672,7 +672,7 @@ for i = 1:length(input_graph)
 end
 
 % Test GUI
-fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
+fi = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'D', d_test, 'NN', nn, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
 gui = GUIElement('PE', fi, 'CLOSEREQ', false);
 gui.get('DRAW')
 gui.get('SHOW')

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceBrainSurface_CV.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportanceBrainSurface_CV.gen.m
@@ -338,8 +338,8 @@ nncv = NNClassifierMLP_CrossValidation('D', {d1, d2, d3}, 'KFOLDS', 2);
 nncv.get('TRAIN');
 
 % Evaluate the feature importance
-fi_template = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
-fi_cv = NNxMLP_FeatureImportanceBrainSurface_CV('BA', ba, 'NNCV', nncv, 'FI_TEMPLATE', fi_template, 'VERBOSE', true);
+fi_template = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
+fi_cv = NNxMLP_FeatureImportanceBrainSurface_CV('BA', ba, 'NNCV', nncv, 'FI_TEMPLATE', fi_template);
 fi_score_cv = fi_cv.get('RESHAPED_AV_FEATURE_IMPORTANCE');
 input_measure = it_list1{1}.get('M_LIST');
 
@@ -349,8 +349,8 @@ assert(isequal(length(fi_score_cv), length(input_measure)), ...
     )
 
 % Test GUI
-fi_template = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false, 'VERBOSE', true);
-fi_cv = NNxMLP_FeatureImportanceBrainSurface_CV('BA', ba, 'NNCV', nncv, 'FI_TEMPLATE', fi_template, 'VERBOSE', true);
+fi_template = NNxMLP_FeatureImportanceBrainSurface('BA', ba, 'P', 2, 'APPLY_BONFERRONI', false, 'APPLY_CONFIDENCE_INTERVALS', false);
+fi_cv = NNxMLP_FeatureImportanceBrainSurface_CV('BA', ba, 'NNCV', nncv, 'FI_TEMPLATE', fi_template);
 gui = GUIElement('PE', fi_cv, 'CLOSEREQ', false);
 gui.get('DRAW')
 gui.get('SHOW')

--- a/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportance_CV.gen.m
+++ b/braph2genesis/neuralnetworks/_NNxMLP_FeatureImportance_CV.gen.m
@@ -412,7 +412,7 @@ nncv.get('TRAIN');
 
 % Evaluate the feature importance
 fi_template = NNxMLP_FeatureImportance('P', 5, 'APPLY_BONFERRONI', true, 'APPLY_CONFIDENCE_INTERVALS', true);
-fi_cv = NNxMLP_FeatureImportance_CV('NNCV', nncv, 'FI_TEMPLATE', fi_template, 'VERBOSE', true);
+fi_cv = NNxMLP_FeatureImportance_CV('NNCV', nncv, 'FI_TEMPLATE', fi_template);
 fi_cv_score = fi_cv.get('RESHAPED_AV_FEATURE_IMPORTANCE');
 input_dp = it_list1{1}.get('INPUT');
 

--- a/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_BUD_CLA.m
+++ b/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_BUD_CLA.m
@@ -121,4 +121,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_BUT_REG.m
+++ b/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_BUT_REG.m
@@ -61,4 +61,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_WU_CLA.m
+++ b/braph2genesis/pipelines/connectivity NN/example_NNCV_CON_WU_CLA.m
@@ -119,4 +119,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity NN/example_NN_CON_CLA.m
+++ b/braph2genesis/pipelines/connectivity NN/example_NN_CON_CLA.m
@@ -108,4 +108,3 @@ nne_test = NNClassifierMLP_Evaluator('D', d_test, 'NN', nn);
 confusion_matrix = nne_test.get('C_MATRIX');
 auc = nne_test.get('AUC');
 av_auc = nne_test.get('MACRO_AUC');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity NN/example_NN_CON_REG.m
+++ b/braph2genesis/pipelines/connectivity NN/example_NN_CON_REG.m
@@ -57,4 +57,3 @@ coeff_determination = nne_test.get('DET');
 mae = nne_test.get('MAE');
 mse = nne_test.get('MSE');
 rmse = nne_test.get('RMSE');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity NN/pipeline_classification_cross_validation_connectivity_but_measure.braph2
+++ b/braph2genesis/pipelines/connectivity NN/pipeline_classification_cross_validation_connectivity_but_measure.braph2
@@ -1,4 +1,4 @@
-%% Pipeline Classification Cross-Validation Connectivity BUD Measure  
+%% Pipeline Classification Cross-Validation Connectivity BUT Measure  
 
 % This is the pipeline script to execute cross-validation with multi-layer perceptron classifier using the graph measures with binary undirected graph at fix thresholds obtained from connectivity data.
 % The connectivity data can be derived from imaging modalities like diffusion weighted imaging (DWI).

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/_NNDataPoint_CON_FUN_MP_REG.gen.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/_NNDataPoint_CON_FUN_MP_REG.gen.m
@@ -177,7 +177,7 @@ Example training-test regression
 %%%% ¡code!
 % ensure the example data is generated
 if ~isfile([fileparts(which('NNDataPoint_CON_FUN_MP_REG')) filesep 'Example data NN REG CON_FUN_MP XLS' filesep 'atlas.xlsx'])
-    create_data_NN_REG_CON_FUN_XSL() % create example files
+    create_data_NN_REG_CON_FUN_XLS() % create example files
 end
 
 example_NN_CON_FUN_MP_REG
@@ -188,7 +188,7 @@ Example cross-validation regression WU
 %%%% ¡code!
 % ensure the example data is generated
 if ~isfile([fileparts(which('NNDataPoint_CON_FUN_MP_REG')) filesep 'Example data NN REG CON_FUN_MP XLS' filesep 'atlas.xlsx'])
-    create_data_NN_REG_CON_FUN_XSL() % create example files
+    create_data_NN_REG_CON_FUN_XLS() % create example files
 end
 
 example_NNCV_CON_FUN_MP_WU_M_REG

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_BUD_REG.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_BUD_REG.m
@@ -80,4 +80,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_BUT_REG.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_BUT_REG.m
@@ -80,4 +80,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_WU_CLA.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NNCV_CON_FUN_MP_WU_CLA.m
@@ -166,4 +166,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NN_CON_FUN_MP_CLA.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NN_CON_FUN_MP_CLA.m
@@ -155,4 +155,3 @@ nne_test = NNClassifierMLP_Evaluator('D', d_test, 'NN', nn);
 confusion_matrix = nne_test.get('C_MATRIX');
 auc = nne_test.get('AUC');
 av_auc = nne_test.get('MACRO_AUC');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NN_CON_FUN_MP_REG.m
+++ b/braph2genesis/pipelines/connectivity-functional multiplex NN/example_NN_CON_FUN_MP_REG.m
@@ -75,4 +75,3 @@ coeff_determination = nne_test.get('DET');
 mae = nne_test.get('MAE');
 mse = nne_test.get('MSE');
 rmse = nne_test.get('RMSE');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/functional NN/example_NNCV_FUN_BUD_REG.m
+++ b/braph2genesis/pipelines/functional NN/example_NNCV_FUN_BUD_REG.m
@@ -62,4 +62,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/functional NN/example_NNCV_FUN_BUT_REG.m
+++ b/braph2genesis/pipelines/functional NN/example_NNCV_FUN_BUT_REG.m
@@ -62,4 +62,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/functional NN/example_NNCV_FUN_WU_CLA.m
+++ b/braph2genesis/pipelines/functional NN/example_NNCV_FUN_WU_CLA.m
@@ -119,4 +119,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/functional NN/example_NN_FUN_CLA.m
+++ b/braph2genesis/pipelines/functional NN/example_NN_FUN_CLA.m
@@ -108,4 +108,3 @@ nne_test = NNClassifierMLP_Evaluator('D', d_test, 'NN', nn);
 confusion_matrix = nne_test.get('C_MATRIX');
 auc = nne_test.get('AUC');
 av_auc = nne_test.get('MACRO_AUC');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/functional NN/example_NN_FUN_REG.m
+++ b/braph2genesis/pipelines/functional NN/example_NN_FUN_REG.m
@@ -57,4 +57,3 @@ coeff_determination = nne_test.get('DET');
 mae = nne_test.get('MAE');
 mse = nne_test.get('MSE');
 rmse = nne_test.get('RMSE');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural NN/example_NNCV_ST_CLA.m
+++ b/braph2genesis/pipelines/structural NN/example_NNCV_ST_CLA.m
@@ -99,4 +99,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural NN/example_NNCV_ST_REG.m
+++ b/braph2genesis/pipelines/structural NN/example_NNCV_ST_REG.m
@@ -51,4 +51,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural NN/example_NN_ST_CLA.m
+++ b/braph2genesis/pipelines/structural NN/example_NN_ST_CLA.m
@@ -108,4 +108,3 @@ nne_test = NNClassifierMLP_Evaluator('D', d_test, 'NN', nn);
 confusion_matrix = nne_test.get('C_MATRIX');
 auc = nne_test.get('AUC');
 av_auc = nne_test.get('MACRO_AUC');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural NN/example_NN_ST_REG.m
+++ b/braph2genesis/pipelines/structural NN/example_NN_ST_REG.m
@@ -57,4 +57,3 @@ coeff_determination = nne_test.get('DET');
 mae = nne_test.get('MAE');
 mse = nne_test.get('MSE');
 rmse = nne_test.get('RMSE');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural multi_modality NN/example_NNCV_ST_MM_CLA.m
+++ b/braph2genesis/pipelines/structural multi_modality NN/example_NNCV_ST_MM_CLA.m
@@ -99,4 +99,3 @@ nncv.get('TRAIN');
 confusion_matrix = nncv.get('C_MATRIX');
 av_auc = nncv.get('AV_AUC');
 av_macro_auc = nncv.get('AV_MACRO_AUC');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural multi_modality NN/example_NNCV_ST_MM_REG.m
+++ b/braph2genesis/pipelines/structural multi_modality NN/example_NNCV_ST_MM_REG.m
@@ -51,4 +51,3 @@ av_coeff_determination = nncv.get('AV_DET');
 av_mae = nncv.get('AV_MAE');
 av_mse = nncv.get('AV_MSE');
 av_rmse = nncv.get('AV_RMSE');
-% av_fi = nncv.get('AV_FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural multi_modality NN/example_NN_ST_MM_CLA.m
+++ b/braph2genesis/pipelines/structural multi_modality NN/example_NN_ST_MM_CLA.m
@@ -108,4 +108,3 @@ nne_test = NNClassifierMLP_Evaluator('D', d_test, 'NN', nn);
 confusion_matrix = nne_test.get('C_MATRIX');
 auc = nne_test.get('AUC');
 av_auc = nne_test.get('MACRO_AUC');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/pipelines/structural multi_modality NN/example_NN_ST_MM_REG.m
+++ b/braph2genesis/pipelines/structural multi_modality NN/example_NN_ST_MM_REG.m
@@ -57,4 +57,3 @@ coeff_determination = nne_test.get('DET');
 mae = nne_test.get('MAE');
 mse = nne_test.get('MSE');
 rmse = nne_test.get('RMSE');
-% fi = nne_test.get('FEATURE_IMPORTANCE'); % % % uncomment this when the feature importance element is ready

--- a/braph2genesis/src/nn/_NNBase.gen.m
+++ b/braph2genesis/src/nn/_NNBase.gen.m
@@ -116,7 +116,7 @@ nn.memorize('MODEL');
 value = [];
 
 %%% ¡prop!
-VERBOSE (metadata, logical) is an indicator to display training progress information.
+VERBOSE (gui, logical) is an indicator to display training progress information.
 %%%% ¡default!
 false
 

--- a/braph2genesis/src/nn/_NNCrossValidation.gen.m
+++ b/braph2genesis/src/nn/_NNCrossValidation.gen.m
@@ -209,7 +209,7 @@ SOLVER (parameter, option) is an option for the solver.
 {'adam' 'sgdm' 'rmsprop'}
 
 %%% ¡prop!
-VERBOSE (metadata, logical) is an indicator to display training progress information.
+VERBOSE (gui, logical) is an indicator to display training progress information.
 %%%% ¡default!
 false
 


### PR DESCRIPTION
This PR fixes the typos, warnings, and unnecessary verbose during unit testing. This PR also tidies up the example scripts of neural networks.

**Typo fixed in NNDataPoint:**
- NNDataPoint_CON_FUN_MP_REG
- NNDataPoint_Graph_REG

**Warning fixed in graph measures:**
- CorePeriphery
- MultiplexCP (Multiplex Core-Periphery)
- Participation

The warning is shown as follows:
![Screenshot from 2024-10-04 15-55-28](https://github.com/user-attachments/assets/2851eafb-6421-4503-8cca-e22e992db12d)
![Screenshot from 2024-10-04 15-56-12](https://github.com/user-attachments/assets/604f2dbe-2f80-405e-b0c5-d05401f49e54)

**Example scripts tidy-up:**
- All neural-networks-related example scripts
