### PR TITLE
All measures callback hz

### DIFF
--- a/braph2/src/analysis/AnalyzeEnsemblePP_MeDict.m
+++ b/braph2/src/analysis/AnalyzeEnsemblePP_MeDict.m
@@ -1058,7 +1058,7 @@ classdef AnalyzeEnsemblePP_MeDict < PanelProp
 			        pr.get('UPDATE')    
 			end
 			function cb_select_all(~, ~) 
-			    g = pr.get('EL').getPropDefaultConditioned(pr.get('PROP'));
+			    g = pr.get('EL').get('GRAPH_TEMPLATE');
 			    m_list = g.get('COMPATIBLE_MEASURES');
 			
 			    pr.set('SELECTED', [1:1:length(m_list)])

--- a/braph2genesis/src/analysis/_AnalyzeEnsemblePP_MeDict.gen.m
+++ b/braph2genesis/src/analysis/_AnalyzeEnsemblePP_MeDict.gen.m
@@ -383,7 +383,7 @@ set(pr.get('TABLE'), 'ContextMenu', contextmenu)
 value = contextmenu;
 %%%% ¡calculate_callbacks!
 function cb_select_all(~, ~) 
-    g = pr.get('EL').getPropDefaultConditioned(pr.get('PROP'));
+    g = pr.get('EL').get('GRAPH_TEMPLATE');
     m_list = g.get('COMPATIBLE_MEASURES');
 
     pr.set('SELECTED', [1:1:length(m_list)])


### PR DESCRIPTION
This pull request fix the bug that when _"all select measure"_ button on the GUI is pressed, the function cannot be executed and error raised.

The following screenshot shows a panel with all selected measure list.

![image](https://github.com/user-attachments/assets/a44c7ff2-9464-4895-8224-c1eb74e1e6b1)
