### PR TITLE
Fix for typo (in pipeline .braph2 file)

### DIFF
--- a/braph2/pipelines/functional NN/pipeline_classification_cross_validation_functional_but_measure.braph2
+++ b/braph2/pipelines/functional NN/pipeline_classification_cross_validation_functional_but_measure.braph2
@@ -1,4 +1,4 @@
-%% Pipeline Classification Cross-Validation Functionaltivity BUT Measure  
+%% Pipeline Classification Cross-Validation Functional BUT Measure  
 
 % This is the pipeline script to execute cross-validation with multi-layer perceptron classifier using the graph measures with binary undirected graph at fix thresholds obtained from functionaltivity data.
 % The functional data can be derived from imaging modalities like functional MRI (fMRI), electroencephalography (EEG) or magnetoencephalography (MEG).

--- a/braph2genesis/pipelines/functional NN/pipeline_classification_cross_validation_functional_but_measure.braph2
+++ b/braph2genesis/pipelines/functional NN/pipeline_classification_cross_validation_functional_but_measure.braph2
@@ -1,4 +1,4 @@
-%% Pipeline Classification Cross-Validation Functionaltivity BUT Measure  
+%% Pipeline Classification Cross-Validation Functional BUT Measure  
 
 % This is the pipeline script to execute cross-validation with multi-layer perceptron classifier using the graph measures with binary undirected graph at fix thresholds obtained from functionaltivity data.
 % The functional data can be derived from imaging modalities like functional MRI (fMRI), electroencephalography (EEG) or magnetoencephalography (MEG).


### PR DESCRIPTION
This PR corrects a typo in braph2/pipelines/functional NN/pipeline_classification_cross_validation_functional_but_measure.braph2.

A thorough search was conducted to ensure no similar typos across all pipelines.